### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 Measurements 0.2.0


### PR DESCRIPTION
since `struct` syntax wouldn't work on early 0.6.0-dev versions,
better to stick with julia-0.5-compatible versions of the package there